### PR TITLE
Fix h/vcenter not working with 3 windows

### DIFF
--- a/nstackLayout.cpp
+++ b/nstackLayout.cpp
@@ -297,7 +297,7 @@ void CHyprNstackLayout::calculateWorkspace(const int& ws) {
     static auto* const ALWAYSCENTER       = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:nstack:layout:center_single_master")->intValue;
     if (*ALWAYSCENTER == 1)
         centerMasterWindow = true;
-    if (!ONLYMASTERS && NODECOUNT-MASTERS < 3) {
+    if (!ONLYMASTERS && NODECOUNT-MASTERS < 2) {
         if (orientation == NSTACK_ORIENTATION_HCENTER) {
             orientation = NSTACK_ORIENTATION_LEFT;
         } else if (orientation == NSTACK_ORIENTATION_VCENTER) {


### PR DESCRIPTION
As it was, these layouts do not activate until there are 3 non-master windows, but they make sense with 2 (e.g. centered master and above/below for vcenter).

There may be some rationale behind the current behavior that I am missing, however.