### PR TITLE
Remove CWindow::m_bMappedX11

### DIFF
--- a/nstackLayout.cpp
+++ b/nstackLayout.cpp
@@ -1403,7 +1403,7 @@ void CHyprNstackLayout::replaceWindowDataWith(CWindow* from, CWindow* to) {
 
 void CHyprNstackLayout::onEnable() {
     for (auto& w : g_pCompositor->m_vWindows) {
-        if (w->m_bIsFloating || !w->m_bMappedX11 || !w->m_bIsMapped || w->isHidden())
+        if (w->m_bIsFloating || !w->m_bIsMapped || w->isHidden())
             continue;
 
         onWindowCreatedTiling(w.get());


### PR DESCRIPTION
Removed in hyprland upstream: https://github.com/hyprwm/Hyprland/commit/9fd928e114d7f57ac03aa7430d9cba41843347de