### PR TITLE
Add Hyprland Lua config compatibility

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,502 @@
+{
+  "nodes": {
+    "aquamarine": {
+      "inputs": {
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776876344,
+        "narHash": "sha256-Ubqb/agkuMJK+k19gjQgHux/eOYRc1sRGoOZOho8+VY=",
+        "owner": "hyprwm",
+        "repo": "aquamarine",
+        "rev": "648a13d0ee1e03a843b3e145b8ece15393058701",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "aquamarine",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "hyprcursor": {
+      "inputs": {
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776511930,
+        "narHash": "sha256-fCpwFiTW0rT7oKJqr3cqHMnkwypSwQKpbtUEtxdkgrM=",
+        "owner": "hyprwm",
+        "repo": "hyprcursor",
+        "rev": "39435900785d0c560c6ae8777d29f28617d031ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprcursor",
+        "type": "github"
+      }
+    },
+    "hyprgraphics": {
+      "inputs": {
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776426399,
+        "narHash": "sha256-RUESLKNikIeEq9ymGJ6nmcDXiSFQpUW1IhJ245nL3xM=",
+        "owner": "hyprwm",
+        "repo": "hyprgraphics",
+        "rev": "68d064434787cf1ed4a2fe257c03c5f52f33cf84",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprgraphics",
+        "type": "github"
+      }
+    },
+    "hyprland": {
+      "inputs": {
+        "aquamarine": "aquamarine",
+        "hyprcursor": "hyprcursor",
+        "hyprgraphics": "hyprgraphics",
+        "hyprland-guiutils": "hyprland-guiutils",
+        "hyprland-protocols": "hyprland-protocols",
+        "hyprlang": "hyprlang",
+        "hyprutils": "hyprutils",
+        "hyprwayland-scanner": "hyprwayland-scanner",
+        "hyprwire": "hyprwire",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pre-commit-hooks": "pre-commit-hooks",
+        "systems": "systems",
+        "xdph": "xdph"
+      },
+      "locked": {
+        "lastModified": 1777207870,
+        "narHash": "sha256-Jld5Lp1HdjRVYJgAnW3vwOPcRUgbfP+IzhcpUjFR2Ns=",
+        "ref": "refs/pull/13817/head",
+        "rev": "c35a8a565bf14fcf71b34663e7bd7683ca3facfd",
+        "revCount": 7174,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/hyprwm/Hyprland"
+      },
+      "original": {
+        "ref": "refs/pull/13817/head",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/hyprwm/Hyprland"
+      }
+    },
+    "hyprland-guiutils": {
+      "inputs": {
+        "aquamarine": [
+          "hyprland",
+          "aquamarine"
+        ],
+        "hyprgraphics": [
+          "hyprland",
+          "hyprgraphics"
+        ],
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
+        "hyprtoolkit": "hyprtoolkit",
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776426575,
+        "narHash": "sha256-KI6nIfVihn/DPaeB5Et46Xg3dkNHrrEtUd5LBBVomB0=",
+        "owner": "hyprwm",
+        "repo": "hyprland-guiutils",
+        "rev": "a968d211048e3ed538e47b84cb3649299578f19d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-guiutils",
+        "type": "github"
+      }
+    },
+    "hyprland-protocols": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772460177,
+        "narHash": "sha256-/6G/MsPvtn7bc4Y32pserBT/Z4SUUdBd4XYJpOEKVR4=",
+        "owner": "hyprwm",
+        "repo": "hyprland-protocols",
+        "rev": "1cb6db5fd6bb8aee419f4457402fa18293ace917",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-protocols",
+        "type": "github"
+      }
+    },
+    "hyprlang": {
+      "inputs": {
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776426736,
+        "narHash": "sha256-rl7i4aY+9p8LysJp7o8uRWahCkpFznCgGHXszlTw7b0=",
+        "owner": "hyprwm",
+        "repo": "hyprlang",
+        "rev": "7833ff33b2e82d3406337b5dcf0d1cec595d83e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprlang",
+        "type": "github"
+      }
+    },
+    "hyprtoolkit": {
+      "inputs": {
+        "aquamarine": [
+          "hyprland",
+          "hyprland-guiutils",
+          "aquamarine"
+        ],
+        "hyprgraphics": [
+          "hyprland",
+          "hyprland-guiutils",
+          "hyprgraphics"
+        ],
+        "hyprlang": [
+          "hyprland",
+          "hyprland-guiutils",
+          "hyprlang"
+        ],
+        "hyprutils": [
+          "hyprland",
+          "hyprland-guiutils",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprland-guiutils",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "hyprland-guiutils",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "hyprland-guiutils",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772462885,
+        "narHash": "sha256-5pHXrQK9zasMnIo6yME6EOXmWGFMSnCITcfKshhKJ9I=",
+        "owner": "hyprwm",
+        "repo": "hyprtoolkit",
+        "rev": "9af245a69fa6b286b88ddfc340afd288e00a6998",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprtoolkit",
+        "type": "github"
+      }
+    },
+    "hyprutils": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776428866,
+        "narHash": "sha256-XfRlBolGtjvalTHJp3XvvpYLBjkMhaZLLU0WqZ91Fcg=",
+        "owner": "hyprwm",
+        "repo": "hyprutils",
+        "rev": "eedd60805cd96d4442586f2ba5fe51d549b12674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprutils",
+        "type": "github"
+      }
+    },
+    "hyprwayland-scanner": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776430932,
+        "narHash": "sha256-Yv3RPiUvl7CAsJgwIVsqcj7akn1gLyJP1F/mocof5hA=",
+        "owner": "hyprwm",
+        "repo": "hyprwayland-scanner",
+        "rev": "4c2fcc06dc9722c97dbb54ba649c69b18ce83d2e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprwayland-scanner",
+        "type": "github"
+      }
+    },
+    "hyprwire": {
+      "inputs": {
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776728575,
+        "narHash": "sha256-z9eGphrArEBpl1O/GCH0wlY6z4K9vA6yWh2gAS6qytU=",
+        "owner": "hyprwm",
+        "repo": "hyprwire",
+        "rev": "f3a80888783702a39691b684d099e16b83ed4702",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprwire",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "hyprland": "hyprland",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    },
+    "xdph": {
+      "inputs": {
+        "hyprland-protocols": [
+          "hyprland",
+          "hyprland-protocols"
+        ],
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776608502,
+        "narHash": "sha256-UH8YoQxx4hFOm6qjMdjRQNRvSejFIR/wBZ8fW1p9sME=",
+        "owner": "hyprwm",
+        "repo": "xdg-desktop-portal-hyprland",
+        "rev": "4a293523d36dfa367e67ec304cc718ea66a8fec2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "xdg-desktop-portal-hyprland",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,81 @@
+{
+  description = "N-stack layout plugin for Hyprland";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    hyprland = {
+      url = "git+https://github.com/hyprwm/Hyprland?submodules=1&ref=refs/pull/13817/head";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    hyprland,
+  }:
+    let
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          hyprlandPkg = hyprland.packages.${system}.hyprland;
+          hyprNStack = pkgs.stdenv.mkDerivation {
+            pname = "hyprNStack";
+            version = "0-unstable-${self.shortRev or "dirty"}";
+
+            src = self;
+
+            strictDeps = true;
+            nativeBuildInputs = [
+              pkgs.pkg-config
+            ];
+            buildInputs = [
+              hyprlandPkg
+            ] ++ hyprlandPkg.buildInputs;
+
+            dontStrip = true;
+
+            installPhase = ''
+              runHook preInstall
+
+              install -Dm755 nstackLayoutPlugin.so \
+                "$out/lib/libhyprNStack.so"
+
+              runHook postInstall
+            '';
+
+            meta = {
+              description = "N-stack layout plugin for Hyprland";
+              homepage = "https://github.com/zakk4223/hyprNStack";
+              license = pkgs.lib.licenses.bsd3;
+              platforms = hyprlandPkg.meta.platforms;
+            };
+          };
+        in {
+          default = hyprNStack;
+          hyprNStack = hyprNStack;
+        });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          hyprlandPkg = hyprland.packages.${system}.hyprland;
+        in {
+          default = pkgs.mkShell {
+            nativeBuildInputs = [
+              pkgs.pkg-config
+            ];
+            buildInputs = [
+              hyprlandPkg
+            ] ++ hyprlandPkg.buildInputs;
+          };
+        });
+    };
+}

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,8 @@
 #include "globals.hpp"
 #include <hyprland/src/config/ConfigManager.hpp>
+#include <hyprland/src/config/values/types/FloatValue.hpp>
+#include <hyprland/src/config/values/types/IntValue.hpp>
+#include <hyprland/src/config/values/types/StringValue.hpp>
 #include <hyprland/src/desktop/DesktopTypes.hpp>
 #include <hyprland/src/desktop/Workspace.hpp>
 #include "nstackLayout.hpp"
@@ -16,21 +19,20 @@ APICALL EXPORT std::string PLUGIN_API_VERSION() {
 APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     PHANDLE = handle;
 
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:nstack:layout:orientation", Hyprlang::STRING{"left"});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:nstack:layout:new_on_top", Hyprlang::INT{0});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:nstack:layout:new_is_master", Hyprlang::INT{1});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:nstack:layout:no_gaps_when_only", Hyprlang::INT{0});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:nstack:layout:special_scale_factor", Hyprlang::FLOAT{0.8f});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:nstack:layout:inherit_fullscreen", Hyprlang::INT{1});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:nstack:layout:stacks", Hyprlang::INT{2});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:nstack:layout:center_single_master", Hyprlang::INT{0});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:nstack:layout:mfact", Hyprlang::FLOAT{0.5f});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:nstack:layout:single_mfact", Hyprlang::FLOAT{0.5f});
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<Config::Values::CStringValue>("plugin:nstack:layout:orientation", "orientation", "left"));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<Config::Values::CIntValue>("plugin:nstack:layout:new_on_top", "new on top", 0));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<Config::Values::CIntValue>("plugin:nstack:layout:new_is_master", "new is master", 0));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<Config::Values::CIntValue>("plugin:nstack:layout:no_gaps_when_only", "no gaps when only", 1));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<Config::Values::CFloatValue>("plugin:nstack:layout:special_scale_factor", "special scale factor", 0.8f));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<Config::Values::CIntValue>("plugin:nstack:layout:inherit_fullscreen", "inherit fullscreen", 1));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<Config::Values::CIntValue>("plugin:nstack:layout:stacks", "stacks", 2));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<Config::Values::CIntValue>("plugin:nstack:layout:center_single_master", "center single master", 0));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<Config::Values::CFloatValue>("plugin:nstack:layout:mfact", "master factor", 0.0f));
+    HyprlandAPI::addConfigValueV2(PHANDLE, makeShared<Config::Values::CFloatValue>("plugin:nstack:layout:single_mfact", "single master factor", 1.0f));
     g_pNstackLayout  = std::make_unique<Layout::Tiled::CHyprNstackAlgorithm>();
 	  if (!HyprlandAPI::addTiledAlgo(PHANDLE, "nStack", &typeid(Layout::Tiled::CHyprNstackAlgorithm), [] { return makeUnique<Layout::Tiled::CHyprNstackAlgorithm>(); })) {
 			HyprlandAPI::addNotification(PHANDLE, "[hyprgollum] addTiledAlgo failed! Can't proceed.", CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
     }
-    HyprlandAPI::reloadConfig();
 
     return {"hyprNStack", "Plugin for column layout", "Zakk", "1.0"};
 }

--- a/nstackLayout.cpp
+++ b/nstackLayout.cpp
@@ -309,7 +309,7 @@ void CHyprNstackAlgorithm::calculateWorkspace() {
 	  });
 
 
-    auto            NUMSTACKS      = m_userWorkspaceData.m_iStackCount.value_or(m_workspaceData.m_iStackCount);
+    auto            NUMSTACKS      = std::max(2, m_userWorkspaceData.m_iStackCount.value_or(m_workspaceData.m_iStackCount));
 
     const auto      NODECOUNT   = getNodesNo();
 

--- a/nstackLayout.cpp
+++ b/nstackLayout.cpp
@@ -1,4 +1,5 @@
 #include "nstackLayout.hpp"
+#include <hyprland/src/config/shared/workspace/WorkspaceRuleManager.hpp>
 #include <hyprland/src/desktop/Workspace.hpp>
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/debug/log/Logger.hpp>
@@ -49,8 +50,9 @@ int CHyprNstackAlgorithm::getMastersCount() {
 
 void CHyprNstackAlgorithm::applyWorkspaceLayoutOptions() {
 
-    const auto         wsrule       = g_pConfigManager->getWorkspaceRuleFor(m_parent->space()->workspace());
-    const auto         wslayoutopts = wsrule.layoutopts;
+    const auto                         wsrule       = Config::workspaceRuleMgr()->getWorkspaceRuleFor(m_parent->space()->workspace());
+    static const std::map<std::string, std::string> EMPTY_LAYOUT_OPTS;
+    const auto&                        wslayoutopts = wsrule ? wsrule->m_layoutopts : EMPTY_LAYOUT_OPTS;
 
     static auto* const orientation   = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:nstack:layout:orientation")->getDataStaticPtr();
     std::string        wsorientation = *orientation;
@@ -845,7 +847,7 @@ std::expected<void, std::string> CHyprNstackAlgorithm::layoutMsg(const std::stri
         g_pInputManager->m_forcedFocus.reset();
     };
 
-    CVarList2 vars(std::string{sv}, 0, 's');
+    Hyprutils::String::CVarList2 vars(std::string{sv}, 0, 's');
 
     if (vars.size() < 1 || vars[0].empty()) {
         Log::logger->log(Log::ERR, "layoutmsg called without params");
@@ -1151,4 +1153,3 @@ void CHyprNstackAlgorithm::buildOrientationCycleVectorFromVars(std::vector<eColO
         }
     }
 }
-

--- a/nstackLayout.cpp
+++ b/nstackLayout.cpp
@@ -26,6 +26,56 @@
 using namespace Layout;
 using namespace Layout::Tiled;
 
+static const CConfigValue<Config::STRING>& nstackOrientation() {
+    static const CConfigValue<Config::STRING> value("plugin:nstack:layout:orientation");
+    return value;
+}
+
+static const CConfigValue<Config::INTEGER>& nstackStacks() {
+    static const CConfigValue<Config::INTEGER> value("plugin:nstack:layout:stacks");
+    return value;
+}
+
+static const CConfigValue<Config::FLOAT>& nstackMasterFactor() {
+    static const CConfigValue<Config::FLOAT> value("plugin:nstack:layout:mfact");
+    return value;
+}
+
+static const CConfigValue<Config::FLOAT>& nstackSingleMasterFactor() {
+    static const CConfigValue<Config::FLOAT> value("plugin:nstack:layout:single_mfact");
+    return value;
+}
+
+static const CConfigValue<Config::FLOAT>& nstackSpecialScaleFactor() {
+    static const CConfigValue<Config::FLOAT> value("plugin:nstack:layout:special_scale_factor");
+    return value;
+}
+
+static const CConfigValue<Config::INTEGER>& nstackNewOnTop() {
+    static const CConfigValue<Config::INTEGER> value("plugin:nstack:layout:new_on_top");
+    return value;
+}
+
+static const CConfigValue<Config::INTEGER>& nstackNewIsMaster() {
+    static const CConfigValue<Config::INTEGER> value("plugin:nstack:layout:new_is_master");
+    return value;
+}
+
+static const CConfigValue<Config::INTEGER>& nstackNoGapsWhenOnly() {
+    static const CConfigValue<Config::INTEGER> value("plugin:nstack:layout:no_gaps_when_only");
+    return value;
+}
+
+static const CConfigValue<Config::INTEGER>& nstackInheritFullscreen() {
+    static const CConfigValue<Config::INTEGER> value("plugin:nstack:layout:inherit_fullscreen");
+    return value;
+}
+
+static const CConfigValue<Config::INTEGER>& nstackCenterSingleMaster() {
+    static const CConfigValue<Config::INTEGER> value("plugin:nstack:layout:center_single_master");
+    return value;
+}
+
 SP<SNstackNodeData> CHyprNstackAlgorithm::getNodeFromTarget(SP<ITarget> x) {
     for (auto& nd : m_lMasterNodesData) {
         if (nd->pTarget == x)
@@ -54,8 +104,7 @@ void CHyprNstackAlgorithm::applyWorkspaceLayoutOptions() {
     static const std::map<std::string, std::string> EMPTY_LAYOUT_OPTS;
     const auto&                        wslayoutopts = wsrule ? wsrule->m_layoutopts : EMPTY_LAYOUT_OPTS;
 
-    static auto* const orientation   = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:nstack:layout:orientation")->getDataStaticPtr();
-    std::string        wsorientation = *orientation;
+    std::string        wsorientation = *nstackOrientation();
 
     if (wslayoutopts.contains("nstack-orientation"))
         wsorientation = wslayoutopts.at("nstack-orientation");
@@ -76,8 +125,7 @@ void CHyprNstackAlgorithm::applyWorkspaceLayoutOptions() {
         m_workspaceData.orientation = NSTACK_ORIENTATION_HCENTER;
     }
 
-    static auto* const NUMSTACKS = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:nstack:layout:stacks")->getDataStaticPtr();
-    auto               wsstacks  = **NUMSTACKS;
+    auto               wsstacks  = *nstackStacks();
 
     if (wslayoutopts.contains("nstack-stacks")) {
         try {
@@ -89,8 +137,7 @@ void CHyprNstackAlgorithm::applyWorkspaceLayoutOptions() {
         m_workspaceData.m_iStackCount = wsstacks;
     }
 
-    static auto* const MFACT   = (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:nstack:layout:mfact")->getDataStaticPtr();
-    auto               wsmfact = **MFACT;
+    auto               wsmfact = *nstackMasterFactor();
     if (wslayoutopts.contains("nstack-mfact")) {
         std::string mfactstr = wslayoutopts.at("nstack-mfact");
         try {
@@ -99,8 +146,7 @@ void CHyprNstackAlgorithm::applyWorkspaceLayoutOptions() {
     }
     m_workspaceData.master_factor = wsmfact;
 
-    static auto* const SMFACT   = (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:nstack:layout:single_mfact")->getDataStaticPtr();
-    auto               wssmfact = **SMFACT;
+    auto               wssmfact = *nstackSingleMasterFactor();
 
     if (wslayoutopts.contains("nstack-single_mfact")) {
         std::string smfactstr = wslayoutopts.at("nstack-single_mfact");
@@ -110,8 +156,7 @@ void CHyprNstackAlgorithm::applyWorkspaceLayoutOptions() {
     }
     m_workspaceData.single_master_factor = wssmfact;
 
-    static auto* const SSFACT   = (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:nstack:layout:special_scale_factor")->getDataStaticPtr();
-    auto               wsssfact = **SSFACT;
+    auto               wsssfact = *nstackSpecialScaleFactor();
     if (wslayoutopts.contains("nstack-special_scale_factor")) {
         std::string ssfactstr = wslayoutopts.at("nstack-special_scale_factor");
         try {
@@ -120,32 +165,27 @@ void CHyprNstackAlgorithm::applyWorkspaceLayoutOptions() {
     }
     m_workspaceData.special_scale_factor = wsssfact;
 
-    static auto* const NEWTOP   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:nstack:layout:new_on_top")->getDataStaticPtr();
-    auto               wsnewtop = **NEWTOP;
+    auto               wsnewtop = *nstackNewOnTop();
     if (wslayoutopts.contains("nstack-new_on_top"))
         wsnewtop = configStringToInt(wslayoutopts.at("nstack-new_on_top")).value_or(0);
     m_workspaceData.new_on_top = wsnewtop;
 
-    static auto* const NEWMASTER   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:nstack:layout:new_is_master")->getDataStaticPtr();
-    auto               wsnewmaster = **NEWMASTER;
+    auto               wsnewmaster = *nstackNewIsMaster();
     if (wslayoutopts.contains("nstack-new_is_master"))
         wsnewmaster = configStringToInt(wslayoutopts.at("nstack-new_is_master")).value_or(0);
     m_workspaceData.new_is_master = wsnewmaster;
 
-    static auto* const NGWO   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:nstack:layout:no_gaps_when_only")->getDataStaticPtr();
-    auto               wsngwo = **NGWO;
+    auto               wsngwo = *nstackNoGapsWhenOnly();
     if (wslayoutopts.contains("nstack-no_gaps_when_only"))
         wsngwo = configStringToInt(wslayoutopts.at("nstack-no_gaps_when_only")).value_or(0);
     m_workspaceData.no_gaps_when_only = wsngwo;
 
-    static auto* const INHERITFS   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:nstack:layout:inherit_fullscreen")->getDataStaticPtr();
-    auto               wsinheritfs = **INHERITFS;
+    auto               wsinheritfs = *nstackInheritFullscreen();
     if (wslayoutopts.contains("nstack-inherit_fullscreen"))
         wsinheritfs = configStringToInt(wslayoutopts.at("nstack-inherit_fullscreen")).value_or(0);
     m_workspaceData.inherit_fullscreen = wsinheritfs;
 
-    static auto* const CENTERSM   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:nstack:layout:center_single_master")->getDataStaticPtr();
-    auto               wscentersm = **CENTERSM;
+    auto               wscentersm = *nstackCenterSingleMaster();
     if (wslayoutopts.contains("nstack-center_single_master"))
         wscentersm = configStringToInt(wslayoutopts.at("nstack-center_single_master")).value_or(0);
     m_workspaceData.center_single_master = wscentersm;


### PR DESCRIPTION
Adds a flake for building against Hyprland Lua config branches and updates nStack config reads so plugin options continue to work when Hyprland is using Lua config values.