### PR TITLE
[codex] Support Hyprland recalculate reason API

### DIFF
--- a/nstackLayout.cpp
+++ b/nstackLayout.cpp
@@ -247,7 +247,12 @@ void CHyprNstackAlgorithm::addTarget(SP<ITarget> target, bool firstMap) {
 }
 
 
+#if HYPRNSTACK_HAS_RECALCULATE_REASON
+void CHyprNstackAlgorithm::recalculate(eRecalculateReason reason) {
+    (void)reason;
+#else
 void CHyprNstackAlgorithm::recalculate() {
+#endif
 	calculateWorkspace();
 }
 
@@ -1151,4 +1156,3 @@ void CHyprNstackAlgorithm::buildOrientationCycleVectorFromVars(std::vector<eColO
         }
     }
 }
-

--- a/nstackLayout.hpp
+++ b/nstackLayout.hpp
@@ -8,7 +8,14 @@
 #include <hyprland/src/layout/algorithm/TiledAlgorithm.hpp>
 #include <hyprland/src/helpers/memory/Memory.hpp>
 #include <hyprland/src/config/ConfigValue.hpp>
+#include <hyprland/src/version.h>
 #include <hyprutils/string/VarList2.hpp>
+
+#if defined(AQUAMARINE_VERSION_MAJOR) && (AQUAMARINE_VERSION_MAJOR > 0 || AQUAMARINE_VERSION_MINOR >= 11)
+#define HYPRNSTACK_HAS_RECALCULATE_REASON 1
+#else
+#define HYPRNSTACK_HAS_RECALCULATE_REASON 0
+#endif
 
 
 
@@ -85,7 +92,11 @@ namespace Layout::Tiled {
 	    virtual void                    movedTarget(SP<ITarget> target, std::optional<Vector2D> focalPoint = std::nullopt);
 	    virtual void                    removeTarget(SP<ITarget> target);
 	    virtual void                    resizeTarget(const Vector2D& Δ, SP<ITarget> target, eRectCorner corner = CORNER_NONE);
+#if HYPRNSTACK_HAS_RECALCULATE_REASON
+	    virtual void                    recalculate(eRecalculateReason reason = RECALCULATE_REASON_UNKNOWN);
+#else
 	    virtual void                    recalculate();
+#endif
 	
 	    virtual SP<ITarget>              getNextCandidate(SP<ITarget> old);
 	    virtual std::expected<void, std::string>                 layoutMsg(const std::string_view& sv);


### PR DESCRIPTION
## Summary

- add a small compile-time guard for Hyprland snapshots where `IModeAlgorithm::recalculate` takes `eRecalculateReason`
- keep the older no-argument override for Hyprland snapshots that have not moved to the reason-aware API

## Notes

This is the standalone version of the compatibility shim. The fully integrated branch in #52 includes this change plus the already-split Lua/config/layout behavior PRs and has been validated through the flake build path.

## Validation

Attempted `nix develop github:colonelpanic8/hyprNStack/hyprland-lua-config-support -c make` from this minimal upstream-main branch. That reaches unrelated pre-existing upstream-main drift (`g_pConfigManager`, `CVarList2`) before this standalone branch can be used as a complete current-Hyprland build target.
